### PR TITLE
DC Motors and Assemblies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,4 @@
-# Mira 3D Format
-
-[![npm version](https://badge.fury.io/js/mirabuf.svg)](https://badge.fury.io/js/mirabuf)
-
-Builds:
-
-[![BuildProto](https://github.com/HiceS/mirabuf/actions/workflows/proto_compile.yml/badge.svg)](https://github.com/HiceS/mirabuf/actions/workflows/proto_compile.yml)
-
-Documentation:
-
-[DOCUMENTATION SITE](https://www.mirabuf.dev/)
-
-[![GenerateDocs](https://github.com/HiceS/mirabuf/actions/workflows/docs_gen.yml/badge.svg?branch=main)](https://github.com/HiceS/mirabuf/actions/workflows/docs_gen.yml)
+# Mira 3D Format  [![npm version](https://badge.fury.io/js/mirabuf.svg)](https://badge.fury.io/js/mirabuf) [![GenerateDocs](https://github.com/HiceS/mirabuf/actions/workflows/docs_gen.yml/badge.svg?branch=main)](https://github.com/HiceS/mirabuf/actions/workflows/docs_gen.yml) [![BuildProto](https://github.com/HiceS/mirabuf/actions/workflows/proto_compile.yml/badge.svg)](https://github.com/HiceS/mirabuf/actions/workflows/proto_compile.yml)
 
 Open source file definition for storing, rendering, and translating physical data from generic 3D model assemblies.
 
@@ -21,6 +9,9 @@ You can find build artifacts from the latest build under the Actions Tab
 - java
 
 Documentation is available as a Build Artifact for now in the GenerateDocs build action.
+
+[DOCUMENTATION SITE](https://www.mirabuf.dev/)
+
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,7 @@ You can find build artifacts from the latest build under the Actions Tab
 
 Documentation is available as a Build Artifact for now in the GenerateDocs build action.
 
-
 ## Building
-
-#### Build
-
-` protoc -I=. --python_out=./libs/python --java_out=./libs/java --cpp_out=./libs/cpp ./build/mirabuf.proto `
 
 ### Build All - Seperate
 
@@ -76,11 +71,12 @@ I opt to use [protobufjs](https://www.npmjs.com/package/protobufjs) to generate 
 
 If you want a zero library implementation you can use the default js_out and rip the build artifact typing.
 
-* Before compiling with this take the time to figure out if commonjs is the right module for you and look over the cli arguments to configure it for however you want to use it. *
+__Before compiling with this take the time to figure out if commonjs is the right module for you and look over the cli arguments to configure it for however you want to use it.__
 
-` npm i -g protobufjs && mkdir libs/node`
+`npm i -g protobufjs && mkdir libs/node`
 
-` pbjs -t static-module -w commonjs -o libs/node/mirabuf.js *.proto `
+`pbjs -t static-module -w commonjs -o libs/node/mirabuf.js *.proto`
 
-` pbts -o mirabuf.d.ts mirabuf.js `
+`cd ./libs/node`
 
+`pbts -o mirabuf.d.ts mirabuf.js`

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-## Mira 3D Format   
+# Mira 3D Format
 
 [![npm version](https://badge.fury.io/js/mirabuf.svg)](https://badge.fury.io/js/mirabuf)
 
 Builds:
 
-[![BuildProto](https://github.com/HiceS/mirabuf/actions/workflows/proto_compile.yml/badge.svg)](https://github.com/HiceS/mirabuf/actions/workflows/proto_compile.yml) 
+[![BuildProto](https://github.com/HiceS/mirabuf/actions/workflows/proto_compile.yml/badge.svg)](https://github.com/HiceS/mirabuf/actions/workflows/proto_compile.yml)
 
 Documentation:
 
-[DOCUMENTATION SITE](https://www.mirabuf.dev/) 
+[DOCUMENTATION SITE](https://www.mirabuf.dev/)
 
 [![GenerateDocs](https://github.com/HiceS/mirabuf/actions/workflows/docs_gen.yml/badge.svg?branch=main)](https://github.com/HiceS/mirabuf/actions/workflows/docs_gen.yml)
 
@@ -37,7 +37,7 @@ go, c#, swift, rust, node can have additional dependencies
 #### Go
 
 ` go install google.golang.org/protobuf/cmd/protoc-gen-go `
-` protoc -I=. --go_out=./libs/go ./*.proto ` 
+` protoc -I=. --go_out=./libs/go ./*.proto `
 
 #### Java
 

--- a/assembly.proto
+++ b/assembly.proto
@@ -48,7 +48,8 @@ message AssemblyReference {
 
     message Instance {
         Info info = 1;      /// Unique Instance ID that can be controlled individually
-        Transform transform_override = 2;   /// Transform in world space that is unique for this instance
+        map<string, PhysicsRecord> physics_record = 2;  /// Record of object as it is moving in the simulation - for each Joint Group
+        Transform transform_override = 3;   /// Transform in world space that is unique for this instance
         // More info here for overriding colors etc in the future I suppose
         // Or something idk
     }

--- a/assembly.proto
+++ b/assembly.proto
@@ -8,9 +8,54 @@ import "types.proto";
 import "joint.proto";
 import "material.proto";
 import "signal.proto";
+import "world.proto";
+import "filetypes.proto";
 
+/**
+ * Assemblies Package File
+ * Contains many assemblies to be packaged together
+ * This object can be loaded directly or you can load a single Assembly
+ */
 message Assemblies {
+    /// Set of assemblies in the world
     repeated Assembly assemblies = 1;
+    /// World Settings and Information
+    World world = 2;
+    /// Extra paths since I forgot to reserve 1
+    reserved 3 to 8;
+}
+
+/**
+ * Assembly Reference
+ * Contains references to an assembly
+ * Can have a reference to any of the following
+ * - Assembly (In-Document)
+ * - Cloud (Cloud Fetched Document)
+ * - Local FS (File System Document Path)
+ * We should consider doing instancing here
+ */
+message AssemblyReference {
+    /// Info contains a unqiue ID for the given instance of an assembly
+    Info info = 1;
+    /// Assembly Type will result in how to assembly exists in the world
+    oneof assembly_type {
+        string assembly = 2; /// Stored as a reference to an assembly in this file
+        filetypes.CloudFile cloud = 3; /// Stored as Cloud File to be fetched and referenced
+        filetypes.LocalFile local = 4; /// Stored as a Local Filesystem File to be requested
+    }
+    /// for future assembly_types
+    reserved 5 to 8;
+
+    message Instance {
+        Info info = 1;      /// Unique Instance ID that can be controlled individually
+        Transform transform_override = 2;   /// Transform in world space that is unique for this instance
+        // More info here for overriding colors etc in the future I suppose
+        // Or something idk
+    }
+    /// The Total number of instances to create in simulation
+    repeated Instance instances = 9;
+    /// for future connections
+    reserved 10 to 40;
 }
 
 /**

--- a/filetypes.proto
+++ b/filetypes.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+import "types.proto";
+
+package mirabuf.filetypes;
+
+/// Describes the type of file so we know what to do once we fetch it
+enum SupportedFileType {
+    /// Simulation format by Us
+    MIRA = 0;
+    /// Scene format by Kronos
+    GLTF = 1;
+    /// Mesh format by Waveform
+    OBJ = 2;
+    reserved 3,4,5;
+    /// Not supported yet
+    USD = 6;
+    /// Not supported yet
+    USDZ = 7;
+    /// Not supported yet
+    STEP = 8;
+    /// Not supported yet
+    URDF = 9;
+}
+
+/**
+ * Cloud
+ * Message for defining a CloudFile
+ * To be fetched from a data server
+ */
+ message CloudFile {
+    /// 1 and 2 are reserved in case we need to verify the authenticity with a hash later down the road
+    reserved 1, 2;
+    /// Directly resolvable to the file perhaps - perhaps we should replicate a query
+    string url = 3;
+    /// Determine if this is supported for translations
+    SupportedFileType file_type = 4;
+    /// File Information Optional
+    FileTypeInformation file_info = 5;
+}
+
+/**
+ * Cloud
+ * Message for defining a CloudFile
+ * To be fetched from a data server
+ */
+ message LocalFile {
+    /// 1 and 2 are reserved in case we need to verify the authenticity with a hash later down the road
+    reserved 1, 2;
+    /// Resolvable to a unique place in the File System - Or in a shared FS
+    string absolutePath = 3;
+    /// Determine if this is supported for translations
+    SupportedFileType file_type = 4;
+    /// File Information Optional
+    FileTypeInformation file_info = 5;
+}

--- a/joint.proto
+++ b/joint.proto
@@ -8,6 +8,10 @@ package mirabuf.joint;
 // You can have a closed chain mechanism or Four-bar (closed loop)
 // Or multiple paths with closed loop like a stewart platform
 
+/**
+ * Joints
+ * A way to define the motion between various group connections
+ */
 message Joints {
     Info info = 1;  /// name, version, uid
     map<string, Joint> joint_definitions = 2;    /// Unique Joint Implementations
@@ -72,7 +76,7 @@ message Joint {
     JointMotion joint_motion_type = 3;
 
     // At what effort does it come apart at. - leave blank if it doesn't
-    float break_magnitude = 4;  
+    float break_magnitude = 4;
 
     // The actual motion of the joint
     oneof JointMotion {
@@ -103,6 +107,8 @@ message Limits {
     float lower = 1;    /// Lower Limit corresponds to default displacement
     float upper = 2;    /// Upper Limit is the joint extent
     float velocity = 3; /// Velocity Max in m/s^2 (angular for rotational)
+    /// Effort is the absolute force a joint can apply for a given instant - ROS has a great article on it http://wiki.ros.org/pr2_controller_manager/safety_limits
+    float effort = 4;
 }
 
 /**
@@ -121,7 +127,7 @@ message Safety {
 }
 
 /**
- * For a single DOF there is data to derive at most 1 degree of freedom.
+ * DOF - representing the construction of a joint motion
  */
 message DOF {
     string name = 1;   /// In case you want to name this degree of freedom

--- a/joint.proto
+++ b/joint.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "types.proto";
+import "motor.proto";
 
 package mirabuf.joint;
 
@@ -17,6 +18,7 @@ message Joints {
     map<string, Joint> joint_definitions = 2;    /// Unique Joint Implementations
     map<string, JointInstance> joint_instances = 3; /// Instances of the Joint Implementations
     repeated RigidGroup rigid_groups = 4;   /// Rigidgroups ?
+    map<string, motor.Motor> motor_definitions = 5;   /// Collection of all Motors exported
 }
 
 // Describes the joint - Not really sure what to do with this for now - TBD
@@ -64,6 +66,7 @@ message JointInstance {
 /**
  * A unqiue implementation of a joint motion
  * Contains information about motion but not assembly relation
+ * NOTE: A spring motion is a joint with no driver
  */
 message Joint {
     /// Joint name, ID, version, etc
@@ -88,6 +91,8 @@ message Joint {
 
     /// Additional information someone can query or store relative to your joint.
     UserData user_data = 8;
+
+    string motor_reference = 9;     /// Motor definition reference to lookup in joints collection
 }
 
 /**
@@ -132,7 +137,7 @@ message Safety {
 message DOF {
     string name = 1;   /// In case you want to name this degree of freedom
     Vector3 axis = 2;  /// Axis the degree of freedom is pivoting by
-    Axis pivotDirection = 3;  /// Direction the axis vector is offset from
+    Axis pivotDirection = 3;  /// Direction the axis vector is offset from - this has an incorrect naming scheme
     Dynamics dynamics = 4;  /// Dynamic properties of this joint pivot
     Limits limits = 5;  /// Limits of this freedom
     float value = 6; /// Current value of the DOF

--- a/libs/node/package.json
+++ b/libs/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirabuf",
-  "version": "1.0.0",
+  "version": "1.2.1",
   "description": "3D Format for Physics Simulation",
   "main": "mirabuf.js",
   "types": "mirabuf.d.ts",

--- a/motor.proto
+++ b/motor.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+import "types.proto";
+
+package mirabuf.motor;
+
+/**
+ * Duty Cycles for electric motors
+ * Affects the dynamic output of the motor
+ * https://www.news.benevelli-group.com/index.php/en/88-what-motor-duty-cycle.html
+ * These each have associated data we are not going to use right now
+ */
+enum DutyCycles {
+    /// S1
+    CONTINUOUS_RUNNING = 0;
+    /// S2
+    SHORT_TIME = 1;
+    /// S3
+    INTERMITTENT_PERIODIC = 2;
+    /// S6 Continuous Operation with Periodic Duty
+    CONTINUOUS_PERIODIC = 3;
+}
+
+/**
+ * A Motor should determine the relationship between an input and joint motion
+ * Could represent something like a DC Motor relationship
+ */
+ message Motor {
+    Info info = 1;
+    oneof motor_type {
+        DCMotor dc_motor = 2;
+    }
+    reserved 3 to 5;
+}
+
+/**
+ * DCMotor Configuration
+ * Parameters to simulate a DC Electric Motor
+ * Still needs some more but overall they are most of the parameters we can use
+ */
+message DCMotor {
+    reserved 1;
+    string reference_url = 2;   /// Reference for purchase page or spec sheet
+    float torque_constant = 3;  /// m-Nm/Amp
+    float emf_constant = 4;     /// mV/rad/sec
+    float resistance = 5;       /// Resistance of Motor - Optional if other values are known
+    uint32 maximum_effeciency = 6;      /// measure in percentage of 100 - generally around 60 - measured under optimal load
+    uint32 maximum_power = 7;           /// measured in Watts
+    DutyCycles duty_cycle = 8;          /// Stated Duty Cycle of motor
+    reserved 9 to 15;
+
+    /// Information usually found on datasheet
+    message Advanced {
+        float free_current = 1;     /// measured in AMPs
+        uint32 free_speed = 2;      /// measured in RPM
+        float stall_current = 3;    /// measure in AMPs
+        float stall_torque = 4;     /// measured in in-oz
+        uint32 input_voltage = 5;   /// measured in Volts DC
+        float resistance_variation = 7;     /// between (K * (N / 4)) and (K * ((N-2) / 4)) where N is number of poles - leave at 0 if unknown
+    }
+
+    Advanced advanced = 16;  /// Optional data that can give a better relationship to the simulation
+}

--- a/types.proto
+++ b/types.proto
@@ -115,6 +115,6 @@ message FileTypeInformation {
     string name = 1;
     /// extension used in file
     string extension = 2;
-    /// unix timestamp
+    /// unix timestamp - this seems unnecessary
     string timestamp = 3;
 }

--- a/types.proto
+++ b/types.proto
@@ -76,6 +76,17 @@ message Transform {
     repeated float spatial_matrix = 1;
 }
 
+/**
+ * Record for instantiating a moving object
+ * Useful for storing moving objects
+ */
+message PhysicsRecord {
+    string id = 1;
+    repeated float spatial_matrix = 2;
+    Vector3 angular_velocity = 3;
+    Vector3 linear_velocity = 4;
+}
+
 // RGBA in expanded form 0-255
 message Color {
     // red 

--- a/world.proto
+++ b/world.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+import "types.proto";
+
+package mirabuf;
+
+/**
+ * World Object
+ * Contains World Simulation settings if present
+ */
+message World {
+    Info info = 1;   /// Basic information (Identifier, Name, Version)
+    string value = 2;   /// the reference ID for whatever kind of graph this is
+}

--- a/world.proto
+++ b/world.proto
@@ -11,4 +11,10 @@ package mirabuf;
 message World {
     Info info = 1;   /// Basic information (Identifier, Name, Version)
     string value = 2;   /// the reference ID for whatever kind of graph this is
+    Vector3 gravity = 3;    /// Vec3 for gravity init
+    float dt = 4;   /// Time between steps
+    float velocity_iterations = 5;  /// Optional for solver
+    float position_iterations = 6;  /// Optional for solver
+
+    bytes serialized_frame = 15;    /// Optional for saving the entire world as a serialized frame
 }


### PR DESCRIPTION
# Changes

I attempted to make the changes so that any additions I have made will not invalidate old files, however I have made many changes and cannot guarantee it so I will make a new major version once tested properly. 

## Motors 

I added the ability to define a given Motor by adding it to the Joints Object in a unique item collection as is standard now,

`map<string, motor.Motor> motor_definitions = 5;   /// Collection of all Motors exported`

This is then made a reference to by the Joint Option

__Essentially saying that all Joint Instances of a Joint share a type of motor which I believe is acceptable__

`string motor_reference = 9;     /// Motor definition reference to lookup in joints collection`

## Assemblies

Now we can store multiple assemblies in a single file and as instances of each other
- Store inside the document
- Store as a relative local path
- Store as a cloud document with URL

We can also store world information to recreate a given simulation

This is used to create a secondary file in the same format that can save the world data

Now Assemblies can also have physics frames to save the last frame they were on when the file itself is saved, eventually this will be extended to save the entire path of the object but for now this works.

## Assembly

Entirely unchanged, can import and export as before